### PR TITLE
improved linux & user flatpak support

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 120,
+  "trailingComma": "none",
+  "tabWidth": 2,
+  "singleQuote": false
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,6 +1998,8 @@ dependencies = [
  "nix",
  "reqwest",
  "serde",
+ "serde-value",
+ "serde_ini",
  "serde_json",
  "tar",
  "thiserror 2.0.9",
@@ -2514,6 +2516,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2903,6 +2914,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "result"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3053,6 +3070,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3061,6 +3088,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_ini"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb236687e2bb073a7521c021949be944641e671b8505a94069ca37b656c81139"
+dependencies = [
+ "result",
+ "serde",
+ "void",
 ]
 
 [[package]]
@@ -3640,6 +3678,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,6 +1995,7 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "flate2",
+ "nix",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ clap_complete = "4.5.41"
 serde = { version = "1.0.217", features = ["derive"] }
 log = "0.4.22"
 env_logger = "0.11.6"
+nix = { version = "0.29.0", features = ["user"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,5 @@ serde = { version = "1.0.217", features = ["derive"] }
 log = "0.4.22"
 env_logger = "0.11.6"
 nix = { version = "0.29.0", features = ["user"] }
+serde_ini = "0.2.0"
+serde-value = "0.7.0"

--- a/crates/libmoonlight/Cargo.toml
+++ b/crates/libmoonlight/Cargo.toml
@@ -16,3 +16,5 @@ serde = { workspace = true }
 clap = { workspace = true }
 thiserror = { workspace = true }
 nix = { workspace = true }
+serde_ini = { workspace = true }
+serde-value = { workspace = true }

--- a/crates/libmoonlight/Cargo.toml
+++ b/crates/libmoonlight/Cargo.toml
@@ -15,3 +15,4 @@ serde_json = { workspace = true }
 serde = { workspace = true }
 clap = { workspace = true }
 thiserror = { workspace = true }
+nix = { workspace = true }

--- a/crates/libmoonlight/src/injector.js
+++ b/crates/libmoonlight/src/injector.js
@@ -23,5 +23,4 @@ function getInjector(override) {
 }
 
 const injector = getInjector(MOONLIGHT_INJECTOR);
-console.error(`injecting ${injector}`);
 require(injector).inject(require("path").resolve(__dirname, `../${PATCHED_ASAR}`));

--- a/crates/libmoonlight/src/injector.js
+++ b/crates/libmoonlight/src/injector.js
@@ -1,9 +1,10 @@
-const os = require("os");
-const path = require("path");
-const process = require("process");
+const os = require("node:os");
+const fs = require("node:fs");
+const path = require("node:path");
+const process = require("node:process");
 
 function getInjector(override) {
-  if (override !== null) return override;
+  if (override !== null && fs.existsSync(override)) return override;
 
   // resolve default path
   switch (os.platform()) {
@@ -23,4 +24,4 @@ function getInjector(override) {
 }
 
 const injector = getInjector(MOONLIGHT_INJECTOR);
-require(injector).inject(require("path").resolve(__dirname, `../${PATCHED_ASAR}`));
+require(injector).inject(path.resolve(__dirname, `../${PATCHED_ASAR}`));

--- a/crates/libmoonlight/src/injector.js
+++ b/crates/libmoonlight/src/injector.js
@@ -1,0 +1,26 @@
+const os = require("os");
+const path = require("path");
+const process = require("process");
+
+function getInjector() {
+  if (MOONLIGHT_INJECTOR !== null) return MOONLIGHT_INJECTOR;
+
+  // resolve default path
+  switch (os.platform()) {
+    case "windows":
+      return path.join(process.env.APPDATA, "moonlight-mod", DOWNLOAD_DIR, "injector.js");
+    case "darwin":
+      return path.join(os.homedir(), "Library", "Application Support", "moonlight-mod", DOWNLOAD_DIR, "injector.js");
+    case "linux":
+    default:
+      return path.join(
+        process.env.XDG_CONFIG_HOME ?? path.join(os.homedir(), ".config"),
+        "moonlight-mod",
+        DOWNLOAD_DIR,
+        "injector.js"
+      );
+  }
+}
+
+console.error(`injecting ${getInjector()}`);
+require(getInjector()).inject(require("path").resolve(__dirname, `../${PATCHED_ASAR}`));

--- a/crates/libmoonlight/src/injector.js
+++ b/crates/libmoonlight/src/injector.js
@@ -2,8 +2,8 @@ const os = require("os");
 const path = require("path");
 const process = require("process");
 
-function getInjector() {
-  if (MOONLIGHT_INJECTOR !== null) return MOONLIGHT_INJECTOR;
+function getInjector(override) {
+  if (override !== null) return override;
 
   // resolve default path
   switch (os.platform()) {
@@ -22,5 +22,6 @@ function getInjector() {
   }
 }
 
-console.error(`injecting ${getInjector()}`);
-require(getInjector()).inject(require("path").resolve(__dirname, `../${PATCHED_ASAR}`));
+const injector = getInjector(MOONLIGHT_INJECTOR);
+console.error(`injecting ${injector}`);
+require(injector).inject(require("path").resolve(__dirname, `../${PATCHED_ASAR}`));

--- a/crates/libmoonlight/src/installer.rs
+++ b/crates/libmoonlight/src/installer.rs
@@ -215,7 +215,9 @@ impl Installer {
 
             "linux" => {
                 let home = std::env::var("HOME").unwrap();
-                let local_share = std::env::var_os("MOONLIGHT_DISCORD_SHARE_LINUX").map(PathBuf::from)
+                let local_share = std::env::var_os("MOONLIGHT_DISCORD_SHARE_LINUX")
+                    .ok_or("XDG_DATA_HOME")
+                    .map(PathBuf::from)
                     .unwrap_or(PathBuf::from(home).join(".local/share"));
 
                 let dirs = vec![

--- a/crates/libmoonlight/src/installer.rs
+++ b/crates/libmoonlight/src/installer.rs
@@ -263,7 +263,7 @@ impl Installer {
         let has = overrides
             .as_ref()
             .and_then(|v| v.context.as_ref())
-            .and_then(|v| v.filesystem.as_ref())
+            .and_then(|v| v.filesystems.as_ref())
             .is_some_and(|v| {
                 v.iter().any(|entry| {
                     entry.path == "xdg-config/moonlight-mod"
@@ -282,10 +282,10 @@ impl Installer {
         }
         let context = overrides.context.as_mut().unwrap();
 
-        if context.filesystem.is_none() {
-            context.filesystem = Some(Default::default());
+        if context.filesystems.is_none() {
+            context.filesystems = Some(Default::default());
         }
-        let filesystem = context.filesystem.as_mut().unwrap();
+        let filesystem = context.filesystems.as_mut().unwrap();
 
         filesystem.push(FlatpakFilesystemOverride {
             path: String::from("xdg-config/moonlight-mod"),

--- a/crates/libmoonlight/src/types.rs
+++ b/crates/libmoonlight/src/types.rs
@@ -159,7 +159,7 @@ impl Default for FlatpakOverrides {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct FlatpakOverridesContext {
-    pub filesystem: Option<FlatpakArray<FlatpakFilesystemOverride>>,
+    pub filesystems: Option<FlatpakArray<FlatpakFilesystemOverride>>,
     #[serde(flatten)]
     other: serde_value::Value,
 }
@@ -167,7 +167,7 @@ pub struct FlatpakOverridesContext {
 impl Default for FlatpakOverridesContext {
     fn default() -> Self {
         Self {
-            filesystem: Some(Default::default()),
+            filesystems: Some(Default::default()),
             other: serde_value::Value::Map(BTreeMap::new()),
         }
     }

--- a/crates/libmoonlight/src/types.rs
+++ b/crates/libmoonlight/src/types.rs
@@ -297,7 +297,8 @@ where
         S: serde::Serializer,
     {
         let as_strings: Vec<String> = self.iter().map(|x| x.to_string()).collect();
-        let v = as_strings.join(";");
+        let mut v = as_strings.join(";");
+        v += ";";
         serializer.serialize_str(&v)
     }
 }
@@ -333,7 +334,12 @@ where
             where
                 E: serde::de::Error,
             {
-                let parts: Vec<String> = v.split(';').map(String::from).collect();
+                let parts: Vec<String> = v
+                    .strip_suffix(";")
+                    .unwrap_or(v)
+                    .split(';')
+                    .map(String::from)
+                    .collect();
                 let mut vec = Vec::with_capacity(parts.len());
 
                 for part in parts {

--- a/crates/libmoonlight/src/types.rs
+++ b/crates/libmoonlight/src/types.rs
@@ -1,7 +1,11 @@
 use crate::get_moonlight_dir;
+use serde::de::Visitor;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fmt::Display;
+use std::marker::PhantomData;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 #[derive(Serialize, Deserialize, clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MoonlightBranch {
@@ -98,6 +102,7 @@ impl Branch {
 pub struct DetectedInstall {
     pub branch: Branch,
     pub path: PathBuf,
+    pub flatpak_id: Option<String>,
 }
 
 // Just DetectedInstall but tracking patched for the UI
@@ -119,4 +124,213 @@ pub struct GitHubReleaseAsset {
 pub struct GitHubRelease {
     pub name: String,
     pub assets: Vec<GitHubReleaseAsset>,
+}
+
+// we only care about filesystem so
+#[derive(Serialize, Deserialize, Debug)]
+pub struct FlatpakOverrides {
+    #[serde(rename = "Context")]
+    pub context: Option<FlatpakOverridesContext>,
+    #[serde(flatten)]
+    other: serde_value::Value,
+}
+
+impl Default for FlatpakOverrides {
+    fn default() -> Self {
+        Self {
+            context: Some(Default::default()),
+            other: serde_value::Value::Map(BTreeMap::new()),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct FlatpakOverridesContext {
+    pub filesystem: Option<FlatpakArray<FlatpakFilesystemOverride>>,
+    #[serde(flatten)]
+    other: serde_value::Value,
+}
+
+impl Default for FlatpakOverridesContext {
+    fn default() -> Self {
+        Self {
+            filesystem: Some(Default::default()),
+            other: serde_value::Value::Map(BTreeMap::new()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FlatpakArray<T> {
+    inner: Vec<T>,
+}
+
+impl<T> Default for FlatpakArray<T> {
+    fn default() -> Self {
+        Self { inner: Vec::new() }
+    }
+}
+
+impl<T> std::ops::Deref for FlatpakArray<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> std::ops::DerefMut for FlatpakArray<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T> From<FlatpakArray<T>> for Vec<T> {
+    fn from(value: FlatpakArray<T>) -> Self {
+        value.inner
+    }
+}
+
+impl<T> From<Vec<T>> for FlatpakArray<T> {
+    fn from(value: Vec<T>) -> Self {
+        Self { inner: value }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub enum FlatpakFilesystemOverridePermission {
+    #[default]
+    ReadWrite,
+    ReadOnly,
+    Create,
+    Off,
+}
+
+#[derive(Debug)]
+pub struct FlatpakFilesystemOverride {
+    pub path: String,
+    pub permission: FlatpakFilesystemOverridePermission,
+}
+
+#[derive(Debug)]
+pub struct FlatpakFilesystemOverrideParseError(String);
+
+impl Display for FlatpakFilesystemOverrideParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid permission: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for FlatpakFilesystemOverrideParseError {}
+
+impl FromStr for FlatpakFilesystemOverride {
+    type Err = FlatpakFilesystemOverrideParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use FlatpakFilesystemOverridePermission::*;
+
+        if let Some(p) = s.strip_prefix('!') {
+            return Ok(Self {
+                path: String::from(p),
+                permission: Off,
+            });
+        }
+
+        match s.split_once(':') {
+            Some((lhs, rhs)) => {
+                let permission = match rhs {
+                    "rw" => ReadWrite,
+                    "ro" => ReadOnly,
+                    "create" => Create,
+                    _ => return Err(FlatpakFilesystemOverrideParseError(rhs.into())),
+                };
+
+                Ok(Self {
+                    path: String::from(lhs),
+                    permission,
+                })
+            }
+            None => Ok(Self {
+                path: String::from(s),
+                permission: Default::default(),
+            }),
+        }
+    }
+}
+
+impl Display for FlatpakFilesystemOverride {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use FlatpakFilesystemOverridePermission::*;
+
+        let p = match self.permission {
+            ReadWrite => "rw",
+            ReadOnly => "ro",
+            Create => "create",
+            Off => return write!(f, "!{}", self.path),
+        };
+
+        write!(f, "{}:{p}", self.path)
+    }
+}
+
+// no one has implemented the flatpak filesystem overrides serialization
+// format correctly except for flatpak itself, so we wont try too hard
+impl<T> Serialize for FlatpakArray<T>
+where
+    T: ToString,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let as_strings: Vec<String> = self.iter().map(|x| x.to_string()).collect();
+        let v = as_strings.join(";");
+        serializer.serialize_str(&v)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for FlatpakArray<T>
+where
+    T: FromStr,
+    T::Err: std::error::Error,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct FlatpakArrayVisitor<T>(PhantomData<T>);
+        impl<T> FlatpakArrayVisitor<T> {
+            pub fn new() -> Self {
+                Self(PhantomData)
+            }
+        }
+
+        impl<T> Visitor<'_> for FlatpakArrayVisitor<T>
+        where
+            T: FromStr,
+            T::Err: std::error::Error,
+        {
+            type Value = FlatpakArray<T>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(formatter, "an array of strings separated by semicolons")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let parts: Vec<String> = v.split(';').map(String::from).collect();
+                let mut vec = Vec::with_capacity(parts.len());
+
+                for part in parts {
+                    vec.push(T::from_str(&part).map_err(E::custom)?);
+                }
+
+                Ok(vec.into())
+            }
+        }
+
+        deserializer.deserialize_str(FlatpakArrayVisitor::<T>::new())
+    }
 }

--- a/crates/libmoonlight/src/util.rs
+++ b/crates/libmoonlight/src/util.rs
@@ -1,3 +1,6 @@
+#[cfg(unix)]
+use nix::unistd::{Uid, User};
+
 use crate::types::{Branch, DetectedInstall, InstallInfo};
 use std::path::{Path, PathBuf};
 
@@ -76,4 +79,19 @@ pub fn get_app_dir(path: &Path) -> crate::Result<PathBuf> {
 #[must_use]
 pub fn get_download_dir() -> PathBuf {
     get_moonlight_dir().join(DOWNLOAD_DIR)
+}
+
+pub fn get_home_dir() -> PathBuf {
+    #[cfg(windows)]
+    unimplemented!();
+    #[cfg(unix)]
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            User::from_uid(Uid::effective())
+                .ok()
+                .flatten()
+                .map(|u| u.dir)
+        })
+        .expect("$HOME to be set or user to be in /etc/passwd")
 }

--- a/crates/libmoonlight/src/util.rs
+++ b/crates/libmoonlight/src/util.rs
@@ -4,7 +4,7 @@ use nix::unistd::{Uid, User};
 use crate::types::{Branch, DetectedInstall, InstallInfo};
 use std::path::{Path, PathBuf};
 
-const DOWNLOAD_DIR: &str = "dist";
+pub const DOWNLOAD_DIR: &str = "dist";
 pub const PATCHED_ASAR: &str = "_app.asar";
 
 pub fn get_moonlight_dir() -> PathBuf {

--- a/crates/libmoonlight/src/util.rs
+++ b/crates/libmoonlight/src/util.rs
@@ -62,6 +62,7 @@ pub fn detect_install(exe: &Path) -> Option<InstallInfo> {
         install: DetectedInstall {
             branch: install_type,
             path: folder.to_path_buf(),
+            flatpak_id: None,
         },
         patched: app_dir.join(PATCHED_ASAR).exists(),
         has_config: false,
@@ -94,4 +95,11 @@ pub fn get_home_dir() -> PathBuf {
                 .map(|u| u.dir)
         })
         .expect("$HOME to be set or user to be in /etc/passwd")
+}
+
+pub fn get_local_share() -> PathBuf {
+    std::env::var_os("MOONLIGHT_DISCORD_SHARE_LINUX")
+        .or_else(|| std::env::var_os("XDG_DATA_HOME"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| get_home_dir().join(".local/share"))
 }


### PR DESCRIPTION
changes:

- respect the XDG specification
- dont hardcode path in injector.js if not necessary
- improve homedir finding logic
- automatically set flatpak overrides like vencord does

results:

- OSs/runtimes with different XDG base directory conventions are now supported (required for flatpak)
- user changing home folder wont break moonlight
- the installation process on linux with (user) flatpaks is now one-click
- ready to package for linux\*

more to come

\*: i am planning on creating a flatpak package for the installer for the team to publish on flathub, which will lead to an extremely simple installation process on linux