### PR TITLE
canonicalize the exe path for patch

### DIFF
--- a/crates/moonlight-cli/src/main.rs
+++ b/crates/moonlight-cli/src/main.rs
@@ -56,6 +56,7 @@ fn main() -> eyre::Result<()> {
         }
 
         Commands::Patch { exe, moonlight } => {
+            let exe = std::fs::canonicalize(&exe)?;
             log::info!("Patching install at {:?}", exe);
             let install = detect_install(&exe);
             if let Some(install) = install {
@@ -73,6 +74,7 @@ fn main() -> eyre::Result<()> {
         }
 
         Commands::Unpatch { exe } => {
+            let exe = std::fs::canonicalize(&exe)?;
             log::info!("Unpatching install at {:?}", exe);
             let install = detect_install(&exe);
             if let Some(install) = install {


### PR DESCRIPTION
wanted for the New Discord Next Gen Linux Experience

before: sad, unhappy, wrinkles
```
$ moonlight-cli patch ~/.config/discord/Discord
[2026-05-04T23:33:48Z INFO  moonlight_cli] Patching install at "/home/luna/.config/discord/Discord"
Error:
   0: unknown error: No such file or directory (os error 2)

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

after: happy, no wrinkles, smooth
```
$ moonlight-cli patch ~/.config/discord/Discord
[2026-05-04T23:56:22Z INFO  moonlight_cli] Patching install at "/home/luna/.config/discord/app-1.0.136/Discord"
[2026-05-04T23:56:22Z WARN  moonlight_cli] Client mod appears to already be patched - unpatching first
[2026-05-04T23:56:22Z INFO  moonlight_cli] Patched install at "/home/luna/.config/discord/app-1.0.136/Discord"
```